### PR TITLE
Adding some lines to the gitignore file :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .env
 Dockerfile
 docker-compose.yml
+.DS_Store
+package-lock.json


### PR DESCRIPTION
At the Dublin AppDev workshop, we had some deploying issues on Heroku, because of the `package-lock.json` files.
Would preventing them to be added to the repo would work @zsobin ?
That's how we handled it on D-Day, but I'd love to hear your insight :)
Thanks :heart: 